### PR TITLE
fixed wrong answers showing up in different cats

### DIFF
--- a/src/app/quiz-component/quiz-component.component.ts
+++ b/src/app/quiz-component/quiz-component.component.ts
@@ -70,6 +70,7 @@ export class QuizComponent implements OnInit {
     this.quizResult = false; // Reset quiz result
     this.correct = false; // Reset feedback flags
     this.incorrect = false;
+    this.userAnswers = [];
 
     if (this.questions.length === 0) {
       // No questions available for this category


### PR DESCRIPTION
fixed that the wrong answers got saved in the array, which caused the answers from one category to show up in the other. Now the array resets once a category is chosen 